### PR TITLE
Add Toto analytics dashboard with 10 charts

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "react-dom": "^18",
         "react-hook-form": "^7.53.0",
         "react-verification-input": "^4.1.2",
+        "recharts": "^3.7.0",
         "tailwind-merge": "^2.3.0",
         "tailwind-variants": "^0.2.1",
         "uuid": "^10.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       react-verification-input:
         specifier: ^4.1.2
         version: 4.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      recharts:
+        specifier: ^3.7.0
+        version: 3.7.0(@types/react@18.3.5)(react-dom@18.3.1(react@18.3.1))(react-is@16.13.1)(react@18.3.1)(redux@5.0.1)
       tailwind-merge:
         specifier: ^2.3.0
         version: 2.5.2
@@ -262,24 +265,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@14.2.3':
     resolution: {integrity: sha512-0D4/oMM2Y9Ta3nGuCcQN8jjJjmDPYpHX9OJzqk42NZGJocU2MqhBq5tWkJrUQOQY9N+In9xOdymzapM09GeiZw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@14.2.3':
     resolution: {integrity: sha512-ENPiNnBNDInBLyUU5ii8PMQh+4XLr4pG51tOp6aJ9xqFQ2iRI6IH0Ds2yJkAzNV1CfyagcyzPfROMViS2wOZ9w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@14.2.3':
     resolution: {integrity: sha512-BTAbq0LnCbF5MtoM7I/9UeUu/8ZBY0i8SFjUMCbPDOLv+un67e2JgyN4pmgfXBwy/I+RHu8q+k+MCkDN6P9ViQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@14.2.3':
     resolution: {integrity: sha512-AEHIw/dhAMLNFJFJIJIyOFDzrzI5bAjI9J26gbO5xhAKHYTZ9Or04BesFPXiAYXDNdrwTP2dQceYA4dL1geu8A==}
@@ -648,11 +655,28 @@ packages:
   '@radix-ui/rect@1.1.0':
     resolution: {integrity: sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg==}
 
+  '@reduxjs/toolkit@2.11.2':
+    resolution: {integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
   '@rushstack/eslint-patch@1.10.4':
     resolution: {integrity: sha512-WJgX9nzTqknM393q1QJDJmoW28kUfEnybeTfVNcNAPnIx210RXm2DiXiHzfNPJNIUUb1tJnz/l4QGtJ30PgWmA==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
@@ -662,6 +686,33 @@ packages:
 
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
+
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
@@ -680,6 +731,9 @@ packages:
 
   '@types/react@18.3.5':
     resolution: {integrity: sha512-WeqMfGJLGuLCqHGYRGHxnKrXcTitc6L/nBUWfWPcTarG3t9PsquqUMuVeXZeca+mglY4Vo5GZjCi0A3Or2lnxA==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@types/uuid@10.0.0':
     resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
@@ -1027,6 +1081,50 @@ packages:
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
@@ -1062,6 +1160,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   deep-equal@2.2.3:
     resolution: {integrity: sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==}
@@ -1166,6 +1267,9 @@ packages:
   es-to-primitive@1.2.1:
     resolution: {integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.44.0:
+    resolution: {integrity: sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg==}
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -1315,6 +1419,9 @@ packages:
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   extract-zip@2.0.1:
     resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
@@ -1529,6 +1636,12 @@ packages:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
+  immer@10.2.0:
+    resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
+
+  immer@11.1.4:
+    resolution: {integrity: sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==}
+
   import-fresh@3.3.0:
     resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
     engines: {node: '>=6'}
@@ -1547,6 +1660,10 @@ packages:
   internal-slot@1.0.7:
     resolution: {integrity: sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==}
     engines: {node: '>= 0.4'}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
@@ -2129,6 +2246,18 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
+  react-redux@9.2.0:
+    resolution: {integrity: sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==}
+    peerDependencies:
+      '@types/react': ^18.2.25 || ^19
+      react: ^18.0 || ^19
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
+
   react-remove-scroll-bar@2.3.6:
     resolution: {integrity: sha512-DtSYaao4mBmX+HDo5YWYdBWQwYIQQshUV/dVxFxK+KM26Wjwp1gZ6rv6OC3oujI6Bfu6Xyg3TwK533AQutsn/g==}
     engines: {node: '>=10'}
@@ -2176,6 +2305,22 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
+  recharts@3.7.0:
+    resolution: {integrity: sha512-l2VCsy3XXeraxIID9fx23eCb6iCBsxUQDnE8tWm6DFdszVAO7WVY/ChAD9wVit01y6B2PMupYiMmQwhgPHc9Ew==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
+
   reflect.getprototypeof@1.0.6:
     resolution: {integrity: sha512-fmfw4XgoDke3kdI6h4xcUz1dG8uaiv5q9gcEwLS4Pnth2kxT+GZ7YehS1JTMGBQmtV7Y4GFGbs2re2NqhdozUg==}
     engines: {node: '>= 0.4'}
@@ -2187,6 +2332,9 @@ packages:
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
+
+  reselect@5.1.1:
+    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -2416,6 +2564,9 @@ packages:
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -2513,12 +2664,20 @@ packages:
       '@types/react':
         optional: true
 
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
     hasBin: true
+
+  victory-vendor@37.3.6:
+    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
   which-boxed-primitive@1.0.2:
     resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==}
@@ -3076,9 +3235,25 @@ snapshots:
 
   '@radix-ui/rect@1.1.0': {}
 
+  '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@18.3.5)(react@18.3.1)(redux@5.0.1))(react@18.3.1)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.1.4
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.1.1
+    optionalDependencies:
+      react: 18.3.1
+      react-redux: 9.2.0(@types/react@18.3.5)(react@18.3.1)(redux@5.0.1)
+
   '@rtsao/scc@1.1.0': {}
 
   '@rushstack/eslint-patch@1.10.4': {}
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@swc/counter@0.1.3': {}
 
@@ -3088,6 +3263,30 @@ snapshots:
       tslib: 2.7.0
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
+
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
 
   '@types/json5@0.0.29': {}
 
@@ -3107,6 +3306,8 @@ snapshots:
     dependencies:
       '@types/prop-types': 15.7.12
       csstype: 3.1.3
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@types/uuid@10.0.0': {}
 
@@ -3518,6 +3719,44 @@ snapshots:
 
   csstype@3.1.3: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
   damerau-levenshtein@1.0.8: {}
 
   data-uri-to-buffer@6.0.2: {}
@@ -3547,6 +3786,8 @@ snapshots:
   debug@4.3.7:
     dependencies:
       ms: 2.1.3
+
+  decimal.js-light@2.5.1: {}
 
   deep-equal@2.2.3:
     dependencies:
@@ -3736,6 +3977,8 @@ snapshots:
       is-date-object: 1.0.5
       is-symbol: 1.0.4
 
+  es-toolkit@1.44.0: {}
+
   escalade@3.2.0: {}
 
   escape-string-regexp@1.0.5: {}
@@ -3787,13 +4030,13 @@ snapshots:
       debug: 4.3.7
       enhanced-resolve: 5.17.1
       eslint: 8.57.0
-      eslint-module-utils: 2.11.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0)(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.11.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.8.0
       is-bun-module: 1.2.1
       is-glob: 4.0.3
     optionalDependencies:
-      eslint-plugin-import: 2.30.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.0)
+      eslint-plugin-import: 2.30.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0)
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
@@ -3810,7 +4053,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.11.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0)(eslint@8.57.0))(eslint@8.57.0):
+  eslint-module-utils@2.11.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -3860,7 +4103,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.11.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0)(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.11.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -4001,6 +4244,8 @@ snapshots:
   estraverse@5.3.0: {}
 
   esutils@2.0.3: {}
+
+  eventemitter3@5.0.4: {}
 
   extract-zip@2.0.1:
     dependencies:
@@ -4238,6 +4483,10 @@ snapshots:
 
   ignore@5.3.2: {}
 
+  immer@10.2.0: {}
+
+  immer@11.1.4: {}
+
   import-fresh@3.3.0:
     dependencies:
       parent-module: 1.0.1
@@ -4257,6 +4506,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.0.6
+
+  internmap@2.0.3: {}
 
   invariant@2.2.4:
     dependencies:
@@ -4793,6 +5044,15 @@ snapshots:
 
   react-is@16.13.1: {}
 
+  react-redux@9.2.0(@types/react@18.3.5)(react@18.3.1)(redux@5.0.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 18.3.1
+      use-sync-external-store: 1.6.0(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.5
+      redux: 5.0.1
+
   react-remove-scroll-bar@2.3.6(@types/react@18.3.5)(react@18.3.1):
     dependencies:
       react: 18.3.1
@@ -4838,6 +5098,32 @@ snapshots:
     dependencies:
       picomatch: 2.3.1
 
+  recharts@3.7.0(@types/react@18.3.5)(react-dom@18.3.1(react@18.3.1))(react-is@16.13.1)(react@18.3.1)(redux@5.0.1):
+    dependencies:
+      '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@18.3.5)(react@18.3.1)(redux@5.0.1))(react@18.3.1)
+      clsx: 2.1.1
+      decimal.js-light: 2.5.1
+      es-toolkit: 1.44.0
+      eventemitter3: 5.0.4
+      immer: 10.2.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-is: 16.13.1
+      react-redux: 9.2.0(@types/react@18.3.5)(react@18.3.1)(redux@5.0.1)
+      reselect: 5.1.1
+      tiny-invariant: 1.3.3
+      use-sync-external-store: 1.6.0(react@18.3.1)
+      victory-vendor: 37.3.6
+    transitivePeerDependencies:
+      - '@types/react'
+      - redux
+
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+
+  redux@5.0.1: {}
+
   reflect.getprototypeof@1.0.6:
     dependencies:
       call-bind: 1.0.7
@@ -4856,6 +5142,8 @@ snapshots:
       set-function-name: 2.0.2
 
   require-directory@2.1.1: {}
+
+  reselect@5.1.1: {}
 
   resolve-from@4.0.0: {}
 
@@ -5137,6 +5425,8 @@ snapshots:
 
   through@2.3.8: {}
 
+  tiny-invariant@1.3.3: {}
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -5244,9 +5534,30 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.5
 
+  use-sync-external-store@1.6.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+
   util-deprecate@1.0.2: {}
 
   uuid@10.0.0: {}
+
+  victory-vendor@37.3.6:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   which-boxed-primitive@1.0.2:
     dependencies:

--- a/src/app/analytics/page.tsx
+++ b/src/app/analytics/page.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { Heading } from '@/common/components/Heading';
+import { Main } from '@/common/components/Layout';
+
+import { AnalyticsPage as AnalyticsContent } from '@/modules/analytics/components/AnalyticsPage';
+
+export default function AnalyticsPage() {
+    return (
+        <Main className="gap-4">
+            <section className="mx-auto w-full max-w-screen-xl px-4 py-10 md:px-8">
+                <Heading as="h1" className="text-2xl font-bold">
+                    Analytics
+                </Heading>
+                <div className="mt-6">
+                    <AnalyticsContent />
+                </div>
+            </section>
+        </Main>
+    );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 
 import { CoreLayout } from '@/common/components/CoreLayout';
 import { inter } from '@/common/components/font/Inter';
+import { NavBar } from '@/common/components/NavBar';
 import { Toast } from '@/common/components/Toast';
 
 import '@/common/styles/globals.css';
@@ -20,7 +21,10 @@ export default function RootLayout({
     return (
         <html className={[inter.variable].join(' ')} lang="en">
             <body>
-                <CoreLayout>{children}</CoreLayout>
+                <CoreLayout>
+                    <NavBar />
+                    {children}
+                </CoreLayout>
                 <Toast />
             </body>
         </html>

--- a/src/common/components/NavBar/NavBar.tsx
+++ b/src/common/components/NavBar/NavBar.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+import { cn } from '@/common/utils/cn';
+
+const tabs = [
+    { label: 'Draw', href: '/' },
+    { label: 'Analytics', href: '/analytics' }
+];
+
+export const NavBar = () => {
+    const pathname = usePathname();
+
+    return (
+        <nav className="sticky top-0 z-header border-b border-white/10 bg-blue-900/60 backdrop-blur-md">
+            <div className="mx-auto flex max-w-screen-xl items-center gap-1 px-4 md:px-8">
+                {tabs.map((tab) => {
+                    const isActive =
+                        tab.href === '/' ? pathname === '/' : pathname.startsWith(tab.href);
+
+                    return (
+                        <Link
+                            key={tab.href}
+                            className={cn(
+                                'relative px-4 py-3 text-sm font-medium transition-colors',
+                                isActive
+                                    ? 'text-text-em-high'
+                                    : 'text-text-em-low hover:text-text-em-mid'
+                            )}
+                            href={tab.href}>
+                            {tab.label}
+                            {isActive && (
+                                <span className="absolute bottom-0 left-0 right-0 h-0.5 bg-element-primary" />
+                            )}
+                        </Link>
+                    );
+                })}
+            </div>
+        </nav>
+    );
+};

--- a/src/common/components/NavBar/index.ts
+++ b/src/common/components/NavBar/index.ts
@@ -1,0 +1,1 @@
+export { NavBar } from './NavBar';

--- a/src/modules/analytics/components/AnalyticsPage/AnalyticsPage.tsx
+++ b/src/modules/analytics/components/AnalyticsPage/AnalyticsPage.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { Heading } from '@/common/components/Heading';
+
+import { useAnalyticsData } from '../../hooks/useAnalyticsData';
+import { ConsecutiveNumbersChart } from '../ConsecutiveNumbersChart';
+import { GapAnalysisChart } from '../GapAnalysisChart';
+import { HotColdNumbers } from '../HotColdNumbers';
+import { JackpotTrendChart } from '../JackpotTrendChart';
+import { NumberFrequencyChart } from '../NumberFrequencyChart';
+import { NumberPairHeatmap } from '../NumberPairHeatmap';
+import { OddEvenHighLowChart } from '../OddEvenHighLowChart';
+import { SumDistributionChart } from '../SumDistributionChart';
+import { TotalPrizePoolChart } from '../TotalPrizePoolChart';
+import { WinnerCountChart } from '../WinnerCountChart';
+
+const SectionHeading = ({ id, title }: { id: string; title: string }) => (
+    <div className="pt-6" id={id}>
+        <Heading as="h2" className="text-xl font-bold">
+            {title}
+        </Heading>
+    </div>
+);
+
+const LoadingSkeleton = () => (
+    <div className="space-y-6">
+        {Array.from({ length: 3 }).map((_, i) => (
+            <div
+                key={i}
+                className="h-[460px] animate-pulse rounded-lg bg-blue-900/30"
+            />
+        ))}
+    </div>
+);
+
+export const AnalyticsPage = () => {
+    const { analytics, loading, totalDraws } = useAnalyticsData();
+
+    if (loading) return <LoadingSkeleton />;
+    if (!analytics) return <p className="text-text-em-low">No data available.</p>;
+
+    return (
+        <div className="space-y-6">
+            {/* Section Nav */}
+            <nav className="flex gap-4 text-sm">
+                <a className="text-text-em-mid hover:text-text-em-high" href="#number-analytics">
+                    Numbers
+                </a>
+                <a className="text-text-em-mid hover:text-text-em-high" href="#prize-analytics">
+                    Prizes
+                </a>
+                <a className="text-text-em-mid hover:text-text-em-high" href="#pattern-analytics">
+                    Patterns
+                </a>
+            </nav>
+
+            <p className="text-sm text-text-em-low">
+                Based on {totalDraws} draws
+            </p>
+
+            {/* Number Analytics */}
+            <SectionHeading id="number-analytics" title="Number Analytics" />
+            <div className="space-y-6">
+                <NumberFrequencyChart data={analytics.numberFrequency} />
+                <HotColdNumbers data={analytics.hotColdNumbers} />
+                <NumberPairHeatmap data={analytics.pairFrequency} />
+                <GapAnalysisChart data={analytics.gapAnalysis} />
+            </div>
+
+            {/* Prize & Winner Analytics */}
+            <SectionHeading id="prize-analytics" title="Prize & Winner Analytics" />
+            <div className="space-y-6">
+                <JackpotTrendChart data={analytics.jackpotTrend} />
+                <WinnerCountChart data={analytics.winnerCounts} />
+                <TotalPrizePoolChart data={analytics.totalPrizePool} />
+            </div>
+
+            {/* Pattern Analytics */}
+            <SectionHeading id="pattern-analytics" title="Pattern Analytics" />
+            <div className="space-y-6">
+                <OddEvenHighLowChart data={analytics.oddEvenHighLow} />
+                <SumDistributionChart data={analytics.sumDistribution} totalDraws={totalDraws} />
+                <ConsecutiveNumbersChart data={analytics.consecutiveNumbers} />
+            </div>
+        </div>
+    );
+};

--- a/src/modules/analytics/components/AnalyticsPage/index.ts
+++ b/src/modules/analytics/components/AnalyticsPage/index.ts
@@ -1,0 +1,1 @@
+export { AnalyticsPage } from './AnalyticsPage';

--- a/src/modules/analytics/components/ChartCard/ChartCard.tsx
+++ b/src/modules/analytics/components/ChartCard/ChartCard.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { ReactNode } from 'react';
+
+import { Heading } from '@/common/components/Heading';
+import { cn } from '@/common/utils/cn';
+
+interface ChartCardProps {
+    title: string;
+    description?: string;
+    children: ReactNode;
+    className?: string;
+}
+
+export const ChartCard = ({ title, description, children, className }: ChartCardProps) => {
+    return (
+        <div
+            className={cn(
+                'space-y-4 rounded-lg border-t border-t-white/30 bg-blue-900/50 px-6 py-6 shadow-lg backdrop-blur md:px-10 md:py-8',
+                className
+            )}>
+            <div>
+                <Heading as="h3" className="text-lg font-bold">
+                    {title}
+                </Heading>
+                {description && (
+                    <p className="mt-1 text-sm text-text-em-low">{description}</p>
+                )}
+            </div>
+            {children}
+        </div>
+    );
+};

--- a/src/modules/analytics/components/ChartCard/index.ts
+++ b/src/modules/analytics/components/ChartCard/index.ts
@@ -1,0 +1,1 @@
+export { ChartCard } from './ChartCard';

--- a/src/modules/analytics/components/ConsecutiveNumbersChart/ConsecutiveNumbersChart.tsx
+++ b/src/modules/analytics/components/ConsecutiveNumbersChart/ConsecutiveNumbersChart.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import {
+    Bar,
+    BarChart,
+    CartesianGrid,
+    ResponsiveContainer,
+    Tooltip,
+    XAxis,
+    YAxis
+} from 'recharts';
+
+import { ChartCard } from '@/modules/analytics/components/ChartCard';
+import { axisTickStyle, CHART_COLORS, tooltipStyle } from '@/modules/analytics/utils/chartTheme';
+import { ConsecutiveNumbersData } from '@/modules/analytics/utils/types';
+
+interface Props {
+    data: ConsecutiveNumbersData;
+}
+
+export const ConsecutiveNumbersChart = ({ data }: Props) => {
+    const chartData = data.distribution.map(({ pairs, count }) => ({
+        label: pairs === 0 ? 'None' : `${pairs} pair${pairs > 1 ? 's' : ''}`,
+        count
+    }));
+
+    return (
+        <ChartCard
+            description={`${data.percentageWithConsecutive}% of draws contain at least one consecutive pair`}
+            title="Consecutive Numbers">
+            <ResponsiveContainer height={350} width="100%">
+                <BarChart data={chartData} margin={{ top: 10, right: 10, bottom: 20, left: 10 }}>
+                    <CartesianGrid stroke={CHART_COLORS.grid} strokeDasharray="3 3" />
+                    <XAxis
+                        dataKey="label"
+                        tick={axisTickStyle}
+                        tickLine={false}
+                    />
+                    <YAxis tick={axisTickStyle} tickLine={false} />
+                    <Tooltip {...tooltipStyle} />
+                    <Bar dataKey="count" fill={CHART_COLORS.secondary} name="Draws" radius={[4, 4, 0, 0]} />
+                </BarChart>
+            </ResponsiveContainer>
+        </ChartCard>
+    );
+};

--- a/src/modules/analytics/components/ConsecutiveNumbersChart/index.ts
+++ b/src/modules/analytics/components/ConsecutiveNumbersChart/index.ts
@@ -1,0 +1,1 @@
+export { ConsecutiveNumbersChart } from './ConsecutiveNumbersChart';

--- a/src/modules/analytics/components/GapAnalysisChart/GapAnalysisChart.tsx
+++ b/src/modules/analytics/components/GapAnalysisChart/GapAnalysisChart.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import {
+    Bar,
+    BarChart,
+    CartesianGrid,
+    Cell,
+    ReferenceLine,
+    ResponsiveContainer,
+    Tooltip,
+    XAxis,
+    YAxis
+} from 'recharts';
+
+import { ChartCard } from '@/modules/analytics/components/ChartCard';
+import { axisTickStyle, CHART_COLORS, tooltipStyle } from '@/modules/analytics/utils/chartTheme';
+import { GapAnalysisItem } from '@/modules/analytics/utils/types';
+
+interface Props {
+    data: GapAnalysisItem[];
+}
+
+const EXPECTED_GAP = 49 / 6; // ~8.17
+
+export const GapAnalysisChart = ({ data }: Props) => {
+    return (
+        <ChartCard
+            description="Average number of draws between appearances of each number. Red = overdue (>1.5x expected)."
+            title="Gap Analysis">
+            <ResponsiveContainer height={400} width="100%">
+                <BarChart data={data} margin={{ top: 10, right: 10, bottom: 20, left: 10 }}>
+                    <CartesianGrid stroke={CHART_COLORS.grid} strokeDasharray="3 3" />
+                    <XAxis
+                        dataKey="number"
+                        interval={1}
+                        tick={{ ...axisTickStyle, fontSize: 10 }}
+                        tickLine={false}
+                    />
+                    <YAxis tick={axisTickStyle} tickLine={false} />
+                    <Tooltip
+                        {...tooltipStyle}
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        formatter={(value: any) => [`${value} draws`, 'Avg Gap']}
+                    />
+                    <ReferenceLine
+                        label={{ fill: CHART_COLORS.textMid, position: 'right', value: 'Expected' }}
+                        stroke={CHART_COLORS.amber}
+                        strokeDasharray="5 5"
+                        y={EXPECTED_GAP}
+                    />
+                    <Bar dataKey="averageGap" radius={[2, 2, 0, 0]}>
+                        {data.map((entry, index) => (
+                            <Cell
+                                key={index}
+                                fill={
+                                    entry.averageGap > EXPECTED_GAP * 1.5
+                                        ? CHART_COLORS.error
+                                        : CHART_COLORS.primary
+                                }
+                            />
+                        ))}
+                    </Bar>
+                </BarChart>
+            </ResponsiveContainer>
+        </ChartCard>
+    );
+};

--- a/src/modules/analytics/components/GapAnalysisChart/index.ts
+++ b/src/modules/analytics/components/GapAnalysisChart/index.ts
@@ -1,0 +1,1 @@
+export { GapAnalysisChart } from './GapAnalysisChart';

--- a/src/modules/analytics/components/HotColdNumbers/HotColdNumbers.tsx
+++ b/src/modules/analytics/components/HotColdNumbers/HotColdNumbers.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import {
+    Bar,
+    BarChart,
+    CartesianGrid,
+    ResponsiveContainer,
+    Tooltip,
+    XAxis,
+    YAxis
+} from 'recharts';
+
+import { SegmentedControl } from '@/common/components/SegmentedControl';
+
+import { ChartCard } from '@/modules/analytics/components/ChartCard';
+import { axisTickStyle, CHART_COLORS, tooltipStyle } from '@/modules/analytics/utils/chartTheme';
+import { HotColdItem } from '@/modules/analytics/utils/types';
+
+interface Props {
+    data: HotColdItem[];
+}
+
+export const HotColdNumbers = ({ data }: Props) => {
+    const [view, setView] = useState('hot');
+
+    const chartData = useMemo(() => {
+        const sorted = [...data].sort((a, b) =>
+            view === 'hot'
+                ? b.recentCount - a.recentCount
+                : a.recentCount - b.recentCount
+        );
+        return sorted.slice(0, 10);
+    }, [data, view]);
+
+    return (
+        <ChartCard
+            description="Most and least frequently drawn numbers in the last 30 draws vs all-time"
+            title="Hot & Cold Numbers">
+            <SegmentedControl
+                options={[
+                    { value: 'hot', label: 'Hot' },
+                    { value: 'cold', label: 'Cold' }
+                ]}
+                value={view}
+                onValueChange={setView}
+            />
+            <ResponsiveContainer height={400} width="100%">
+                <BarChart data={chartData} margin={{ top: 10, right: 10, bottom: 20, left: 10 }}>
+                    <CartesianGrid stroke={CHART_COLORS.grid} strokeDasharray="3 3" />
+                    <XAxis
+                        dataKey="number"
+                        tick={axisTickStyle}
+                        tickLine={false}
+                    />
+                    <YAxis tick={axisTickStyle} tickLine={false} />
+                    <Tooltip {...tooltipStyle} />
+                    <Bar
+                        dataKey="recentCount"
+                        fill={view === 'hot' ? CHART_COLORS.amber : '#3B82F6'}
+                        name="Last 30 draws"
+                        radius={[2, 2, 0, 0]}
+                    />
+                    <Bar
+                        dataKey="allTimeCount"
+                        fill={CHART_COLORS.textLow}
+                        name="All-time"
+                        radius={[2, 2, 0, 0]}
+                    />
+                </BarChart>
+            </ResponsiveContainer>
+        </ChartCard>
+    );
+};

--- a/src/modules/analytics/components/HotColdNumbers/index.ts
+++ b/src/modules/analytics/components/HotColdNumbers/index.ts
@@ -1,0 +1,1 @@
+export { HotColdNumbers } from './HotColdNumbers';

--- a/src/modules/analytics/components/JackpotTrendChart/JackpotTrendChart.tsx
+++ b/src/modules/analytics/components/JackpotTrendChart/JackpotTrendChart.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import {
+    Area,
+    AreaChart,
+    CartesianGrid,
+    ResponsiveContainer,
+    Tooltip,
+    XAxis,
+    YAxis
+} from 'recharts';
+
+import { formatAmount } from '@/common/utils';
+
+import { ChartCard } from '@/modules/analytics/components/ChartCard';
+import { axisTickStyle, CHART_COLORS, tooltipStyle } from '@/modules/analytics/utils/chartTheme';
+import { JackpotTrendItem } from '@/modules/analytics/utils/types';
+
+interface Props {
+    data: JackpotTrendItem[];
+}
+
+const formatYAxis = (value: number) => {
+    if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+    if (value >= 1_000) return `${(value / 1_000).toFixed(0)}K`;
+    return String(value);
+};
+
+export const JackpotTrendChart = ({ data }: Props) => {
+    return (
+        <ChartCard
+            description="Group 1 prize amounts over time. Spikes indicate rollovers."
+            title="Jackpot Trend (Group 1)">
+            <ResponsiveContainer height={400} width="100%">
+                <AreaChart data={data} margin={{ top: 10, right: 10, bottom: 20, left: 10 }}>
+                    <defs>
+                        <linearGradient id="jackpotGradient" x1="0" x2="0" y1="0" y2="1">
+                            <stop offset="5%" stopColor={CHART_COLORS.primary} stopOpacity={0.4} />
+                            <stop offset="95%" stopColor={CHART_COLORS.primary} stopOpacity={0} />
+                        </linearGradient>
+                    </defs>
+                    <CartesianGrid stroke={CHART_COLORS.grid} strokeDasharray="3 3" />
+                    <XAxis
+                        dataKey="drawNumber"
+                        tick={axisTickStyle}
+                        tickLine={false}
+                    />
+                    <YAxis
+                        tick={axisTickStyle}
+                        tickFormatter={formatYAxis}
+                        tickLine={false}
+                    />
+                    <Tooltip
+                        {...tooltipStyle}
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        formatter={(value: any) => [formatAmount(value), 'Jackpot']}
+                        labelFormatter={(label) => `Draw #${label}`}
+                    />
+                    <Area
+                        dataKey="prize"
+                        fill="url(#jackpotGradient)"
+                        stroke={CHART_COLORS.primary}
+                        strokeWidth={2}
+                        type="monotone"
+                    />
+                </AreaChart>
+            </ResponsiveContainer>
+        </ChartCard>
+    );
+};

--- a/src/modules/analytics/components/JackpotTrendChart/index.ts
+++ b/src/modules/analytics/components/JackpotTrendChart/index.ts
@@ -1,0 +1,1 @@
+export { JackpotTrendChart } from './JackpotTrendChart';

--- a/src/modules/analytics/components/NumberFrequencyChart/NumberFrequencyChart.tsx
+++ b/src/modules/analytics/components/NumberFrequencyChart/NumberFrequencyChart.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import {
+    Bar,
+    BarChart,
+    CartesianGrid,
+    ResponsiveContainer,
+    Tooltip,
+    XAxis,
+    YAxis
+} from 'recharts';
+
+import { ChartCard } from '@/modules/analytics/components/ChartCard';
+import { axisTickStyle, CHART_COLORS, tooltipStyle } from '@/modules/analytics/utils/chartTheme';
+import { NumberFrequencyItem } from '@/modules/analytics/utils/types';
+
+interface Props {
+    data: NumberFrequencyItem[];
+}
+
+export const NumberFrequencyChart = ({ data }: Props) => {
+    return (
+        <ChartCard
+            description="How often each number (1-49) appears as a winning number"
+            title="Number Frequency">
+            <ResponsiveContainer height={400} width="100%">
+                <BarChart data={data} margin={{ top: 10, right: 10, bottom: 20, left: 10 }}>
+                    <CartesianGrid stroke={CHART_COLORS.grid} strokeDasharray="3 3" />
+                    <XAxis
+                        dataKey="number"
+                        interval={1}
+                        tick={{ ...axisTickStyle, fontSize: 10 }}
+                        tickLine={false}
+                    />
+                    <YAxis tick={axisTickStyle} tickLine={false} />
+                    <Tooltip
+                        {...tooltipStyle}
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        formatter={(value: any, _: any, entry: any) => [
+                            `${value} times (${entry.payload.percentage.toFixed(1)}%)`,
+                            'Appearances'
+                        ]}
+                    />
+                    <Bar dataKey="count" fill={CHART_COLORS.primary} radius={[2, 2, 0, 0]} />
+                </BarChart>
+            </ResponsiveContainer>
+        </ChartCard>
+    );
+};

--- a/src/modules/analytics/components/NumberFrequencyChart/index.ts
+++ b/src/modules/analytics/components/NumberFrequencyChart/index.ts
@@ -1,0 +1,1 @@
+export { NumberFrequencyChart } from './NumberFrequencyChart';

--- a/src/modules/analytics/components/NumberPairHeatmap/NumberPairHeatmap.tsx
+++ b/src/modules/analytics/components/NumberPairHeatmap/NumberPairHeatmap.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+import { ChartCard } from '@/modules/analytics/components/ChartCard';
+import { CHART_COLORS } from '@/modules/analytics/utils/chartTheme';
+import { PairFrequencyItem } from '@/modules/analytics/utils/types';
+
+interface Props {
+    data: PairFrequencyItem[];
+}
+
+const interpolateColor = (ratio: number): string => {
+    const r = Math.round(22 + (43 - 22) * ratio);
+    const g = Math.round(27 + (113 - 27) * ratio);
+    const b = Math.round(34 + (233 - 34) * ratio);
+    return `rgb(${r},${g},${b})`;
+};
+
+export const NumberPairHeatmap = ({ data }: Props) => {
+    const [hoveredPair, setHoveredPair] = useState<{ num1: number; num2: number; count: number } | null>(null);
+
+    const { matrix, maxCount } = useMemo(() => {
+        const m = new Map<string, number>();
+        let max = 0;
+        for (const { num1, num2, count } of data) {
+            m.set(`${num1}-${num2}`, count);
+            if (count > max) max = count;
+        }
+        return { matrix: m, maxCount: max };
+    }, [data]);
+
+    const top20 = data.slice(0, 20);
+    const cellSize = 7;
+    const gridSize = 49 * cellSize;
+
+    return (
+        <ChartCard
+            description="How often pairs of numbers appear together. Brighter = more frequent."
+            title="Number Pair Frequency">
+            <div className="flex flex-col gap-6 lg:flex-row">
+                {/* Heatmap - hidden on mobile */}
+                <div className="hidden md:block">
+                    <div className="relative">
+                        {hoveredPair && (
+                            <div className="absolute -top-8 left-0 rounded bg-surface-base px-2 py-1 text-xs text-text-em-high">
+                                ({hoveredPair.num1}, {hoveredPair.num2}) = {hoveredPair.count} times
+                            </div>
+                        )}
+                        <svg
+                            height={gridSize + 20}
+                            viewBox={`0 0 ${gridSize + 20} ${gridSize + 20}`}
+                            width={gridSize + 20}>
+                            {Array.from({ length: 49 }, (_, i) =>
+                                Array.from({ length: 49 }, (_, j) => {
+                                    if (i >= j) return null;
+                                    const num1 = i + 1;
+                                    const num2 = j + 1;
+                                    const count = matrix.get(`${num1}-${num2}`) ?? 0;
+                                    const ratio = maxCount > 0 ? count / maxCount : 0;
+                                    return (
+                                        <rect
+                                            key={`${i}-${j}`}
+                                            fill={count > 0 ? interpolateColor(ratio) : CHART_COLORS.background}
+                                            height={cellSize}
+                                            width={cellSize}
+                                            x={j * cellSize + 10}
+                                            y={i * cellSize + 10}
+                                            onMouseEnter={() => setHoveredPair({ num1, num2, count })}
+                                            onMouseLeave={() => setHoveredPair(null)}
+                                        />
+                                    );
+                                })
+                            )}
+                        </svg>
+                    </div>
+                </div>
+
+                {/* Top pairs table */}
+                <div className="flex-1">
+                    <p className="mb-2 text-sm font-medium text-text-em-mid">Top 20 Pairs</p>
+                    <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm">
+                        {top20.map(({ num1, num2, count }, i) => (
+                            <div key={i} className="flex justify-between font-mono">
+                                <span className="text-text-em-high">
+                                    ({num1}, {num2})
+                                </span>
+                                <span className="text-text-em-low">{count}x</span>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            </div>
+        </ChartCard>
+    );
+};

--- a/src/modules/analytics/components/NumberPairHeatmap/index.ts
+++ b/src/modules/analytics/components/NumberPairHeatmap/index.ts
@@ -1,0 +1,1 @@
+export { NumberPairHeatmap } from './NumberPairHeatmap';

--- a/src/modules/analytics/components/OddEvenHighLowChart/OddEvenHighLowChart.tsx
+++ b/src/modules/analytics/components/OddEvenHighLowChart/OddEvenHighLowChart.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import {
+    Bar,
+    BarChart,
+    CartesianGrid,
+    Cell,
+    Pie,
+    PieChart,
+    ResponsiveContainer,
+    Tooltip,
+    XAxis,
+    YAxis
+} from 'recharts';
+
+import { SegmentedControl } from '@/common/components/SegmentedControl';
+
+import { ChartCard } from '@/modules/analytics/components/ChartCard';
+import { axisTickStyle, CHART_COLORS, tooltipStyle } from '@/modules/analytics/utils/chartTheme';
+import { OddEvenHighLowItem } from '@/modules/analytics/utils/types';
+
+interface Props {
+    data: OddEvenHighLowItem[];
+}
+
+const PIE_COLORS = [CHART_COLORS.primary, CHART_COLORS.amber];
+
+export const OddEvenHighLowChart = ({ data }: Props) => {
+    const [view, setView] = useState('oddeven');
+
+    const summary = useMemo(() => {
+        const totalOdd = data.reduce((s, d) => s + d.oddCount, 0);
+        const totalHigh = data.reduce((s, d) => s + d.highCount, 0);
+        const total = data.length * 6;
+        return {
+            oddEven: [
+                { name: 'Odd', value: totalOdd },
+                { name: 'Even', value: total - totalOdd }
+            ],
+            highLow: [
+                { name: 'High (25-49)', value: totalHigh },
+                { name: 'Low (1-24)', value: total - totalHigh }
+            ]
+        };
+    }, [data]);
+
+    const isOddEven = view === 'oddeven';
+    const barKey1 = isOddEven ? 'oddCount' : 'highCount';
+    const barKey2 = isOddEven ? 'evenCount' : 'lowCount';
+    const label1 = isOddEven ? 'Odd' : 'High (25-49)';
+    const label2 = isOddEven ? 'Even' : 'Low (1-24)';
+    const pieData = isOddEven ? summary.oddEven : summary.highLow;
+
+    return (
+        <ChartCard
+            description="Distribution of odd vs even and high vs low numbers per draw"
+            title="Odd/Even & High/Low Distribution">
+            <SegmentedControl
+                options={[
+                    { value: 'oddeven', label: 'Odd / Even' },
+                    { value: 'highlow', label: 'High / Low' }
+                ]}
+                value={view}
+                onValueChange={setView}
+            />
+            <div className="flex flex-col gap-6 lg:flex-row">
+                <div className="flex-1">
+                    <ResponsiveContainer height={350} width="100%">
+                        <BarChart
+                            data={data}
+                            margin={{ top: 10, right: 10, bottom: 20, left: 10 }}
+                            stackOffset="none">
+                            <CartesianGrid stroke={CHART_COLORS.grid} strokeDasharray="3 3" />
+                            <XAxis
+                                dataKey="drawNumber"
+                                tick={axisTickStyle}
+                                tickLine={false}
+                            />
+                            <YAxis domain={[0, 6]} tick={axisTickStyle} tickLine={false} />
+                            <Tooltip
+                                {...tooltipStyle}
+                                labelFormatter={(label) => `Draw #${label}`}
+                            />
+                            <Bar
+                                dataKey={barKey1}
+                                fill={CHART_COLORS.primary}
+                                name={label1}
+                                stackId="a"
+                            />
+                            <Bar
+                                dataKey={barKey2}
+                                fill={CHART_COLORS.amber}
+                                name={label2}
+                                stackId="a"
+                            />
+                        </BarChart>
+                    </ResponsiveContainer>
+                </div>
+                <div className="flex flex-col items-center">
+                    <p className="mb-2 text-sm font-medium text-text-em-mid">Overall Split</p>
+                    <ResponsiveContainer height={200} width={200}>
+                        <PieChart>
+                            <Pie
+                                cx="50%"
+                                cy="50%"
+                                data={pieData}
+                                dataKey="value"
+                                innerRadius={50}
+                                outerRadius={80}
+                                paddingAngle={2}>
+                                {pieData.map((_, i) => (
+                                    <Cell key={i} fill={PIE_COLORS[i]} />
+                                ))}
+                            </Pie>
+                            <Tooltip {...tooltipStyle} />
+                        </PieChart>
+                    </ResponsiveContainer>
+                    <div className="flex gap-4 text-xs">
+                        <span className="flex items-center gap-1">
+                            <span
+                                className="inline-block h-2.5 w-2.5 rounded-full"
+                                style={{ background: PIE_COLORS[0] }}
+                            />
+                            {label1}
+                        </span>
+                        <span className="flex items-center gap-1">
+                            <span
+                                className="inline-block h-2.5 w-2.5 rounded-full"
+                                style={{ background: PIE_COLORS[1] }}
+                            />
+                            {label2}
+                        </span>
+                    </div>
+                </div>
+            </div>
+        </ChartCard>
+    );
+};

--- a/src/modules/analytics/components/OddEvenHighLowChart/index.ts
+++ b/src/modules/analytics/components/OddEvenHighLowChart/index.ts
@@ -1,0 +1,1 @@
+export { OddEvenHighLowChart } from './OddEvenHighLowChart';

--- a/src/modules/analytics/components/SumDistributionChart/SumDistributionChart.tsx
+++ b/src/modules/analytics/components/SumDistributionChart/SumDistributionChart.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useMemo } from 'react';
+import {
+    Bar,
+    BarChart,
+    CartesianGrid,
+    ResponsiveContainer,
+    Tooltip,
+    XAxis,
+    YAxis
+} from 'recharts';
+
+import { ChartCard } from '@/modules/analytics/components/ChartCard';
+import { axisTickStyle, CHART_COLORS, tooltipStyle } from '@/modules/analytics/utils/chartTheme';
+import { SumDistributionItem } from '@/modules/analytics/utils/types';
+
+interface Props {
+    data: SumDistributionItem[];
+    totalDraws: number;
+}
+
+export const SumDistributionChart = ({ data, totalDraws }: Props) => {
+    const meanSum = useMemo(() => {
+        // Mean of 6 numbers chosen from 1-49 = 6 * 25 = 150
+        // But compute actual from data distribution
+        let total = 0;
+        let count = 0;
+        for (const bin of data) {
+            const [start, end] = bin.sumRange.split('-').map(Number);
+            const mid = (start + end) / 2;
+            total += mid * bin.count;
+            count += bin.count;
+        }
+        return count > 0 ? Math.round(total / count) : 150;
+    }, [data]);
+
+    return (
+        <ChartCard
+            description={`Distribution of the sum of 6 winning numbers per draw. Mean: ~${meanSum}`}
+            title="Sum of Winning Numbers">
+            <ResponsiveContainer height={400} width="100%">
+                <BarChart data={data} margin={{ top: 10, right: 10, bottom: 20, left: 10 }}>
+                    <CartesianGrid stroke={CHART_COLORS.grid} strokeDasharray="3 3" />
+                    <XAxis
+                        dataKey="sumRange"
+                        tick={axisTickStyle}
+                        tickLine={false}
+                    />
+                    <YAxis tick={axisTickStyle} tickLine={false} />
+                    <Tooltip
+                        {...tooltipStyle}
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        formatter={(value: any) => [
+                            `${value} draws (${((value / totalDraws) * 100).toFixed(1)}%)`,
+                            'Count'
+                        ]}
+                    />
+                    <Bar dataKey="count" fill={CHART_COLORS.primary} radius={[4, 4, 0, 0]} />
+                </BarChart>
+            </ResponsiveContainer>
+        </ChartCard>
+    );
+};

--- a/src/modules/analytics/components/SumDistributionChart/index.ts
+++ b/src/modules/analytics/components/SumDistributionChart/index.ts
@@ -1,0 +1,1 @@
+export { SumDistributionChart } from './SumDistributionChart';

--- a/src/modules/analytics/components/TotalPrizePoolChart/TotalPrizePoolChart.tsx
+++ b/src/modules/analytics/components/TotalPrizePoolChart/TotalPrizePoolChart.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import {
+    Area,
+    AreaChart,
+    CartesianGrid,
+    ResponsiveContainer,
+    Tooltip,
+    XAxis,
+    YAxis
+} from 'recharts';
+
+import { formatAmount } from '@/common/utils';
+
+import { ChartCard } from '@/modules/analytics/components/ChartCard';
+import { axisTickStyle, CHART_COLORS, tooltipStyle } from '@/modules/analytics/utils/chartTheme';
+import { TotalPrizePoolItem } from '@/modules/analytics/utils/types';
+
+interface Props {
+    data: TotalPrizePoolItem[];
+}
+
+const formatYAxis = (value: number) => {
+    if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+    if (value >= 1_000) return `${(value / 1_000).toFixed(0)}K`;
+    return String(value);
+};
+
+export const TotalPrizePoolChart = ({ data }: Props) => {
+    return (
+        <ChartCard
+            description="Sum of all group payouts (prize x winners) per draw"
+            title="Total Prize Pool per Draw">
+            <ResponsiveContainer height={400} width="100%">
+                <AreaChart data={data} margin={{ top: 10, right: 10, bottom: 20, left: 10 }}>
+                    <defs>
+                        <linearGradient id="poolGradient" x1="0" x2="0" y1="0" y2="1">
+                            <stop offset="5%" stopColor={CHART_COLORS.secondary} stopOpacity={0.4} />
+                            <stop offset="95%" stopColor={CHART_COLORS.secondary} stopOpacity={0} />
+                        </linearGradient>
+                    </defs>
+                    <CartesianGrid stroke={CHART_COLORS.grid} strokeDasharray="3 3" />
+                    <XAxis
+                        dataKey="drawNumber"
+                        tick={axisTickStyle}
+                        tickLine={false}
+                    />
+                    <YAxis
+                        tick={axisTickStyle}
+                        tickFormatter={formatYAxis}
+                        tickLine={false}
+                    />
+                    <Tooltip
+                        {...tooltipStyle}
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        formatter={(value: any) => [formatAmount(value), 'Total Payout']}
+                        labelFormatter={(label) => `Draw #${label}`}
+                    />
+                    <Area
+                        dataKey="totalPool"
+                        fill="url(#poolGradient)"
+                        stroke={CHART_COLORS.secondary}
+                        strokeWidth={2}
+                        type="monotone"
+                    />
+                </AreaChart>
+            </ResponsiveContainer>
+        </ChartCard>
+    );
+};

--- a/src/modules/analytics/components/TotalPrizePoolChart/index.ts
+++ b/src/modules/analytics/components/TotalPrizePoolChart/index.ts
@@ -1,0 +1,1 @@
+export { TotalPrizePoolChart } from './TotalPrizePoolChart';

--- a/src/modules/analytics/components/WinnerCountChart/WinnerCountChart.tsx
+++ b/src/modules/analytics/components/WinnerCountChart/WinnerCountChart.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useState } from 'react';
+import {
+    CartesianGrid,
+    Line,
+    LineChart,
+    ResponsiveContainer,
+    Tooltip,
+    XAxis,
+    YAxis
+} from 'recharts';
+
+import { SegmentedControl } from '@/common/components/SegmentedControl';
+
+import { ChartCard } from '@/modules/analytics/components/ChartCard';
+import { axisTickStyle, CHART_COLORS, CHART_PALETTE, tooltipStyle } from '@/modules/analytics/utils/chartTheme';
+import { WinnerCountItem } from '@/modules/analytics/utils/types';
+
+interface Props {
+    data: WinnerCountItem[];
+}
+
+const formatYAxis = (value: number) => {
+    if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+    if (value >= 1_000) return `${(value / 1_000).toFixed(0)}K`;
+    return String(value);
+};
+
+const groupSets = {
+    upper: {
+        keys: ['group1', 'group2', 'group3', 'group4'] as const,
+        labels: ['Group 1', 'Group 2', 'Group 3', 'Group 4']
+    },
+    lower: {
+        keys: ['group5', 'group6', 'group7'] as const,
+        labels: ['Group 5', 'Group 6', 'Group 7']
+    }
+};
+
+export const WinnerCountChart = ({ data }: Props) => {
+    const [view, setView] = useState('upper');
+    const set = view === 'upper' ? groupSets.upper : groupSets.lower;
+
+    return (
+        <ChartCard
+            description="Number of winners per prize group over time"
+            title="Winner Count Trends">
+            <SegmentedControl
+                options={[
+                    { value: 'upper', label: 'Groups 1-4' },
+                    { value: 'lower', label: 'Groups 5-7' }
+                ]}
+                value={view}
+                onValueChange={setView}
+            />
+            <ResponsiveContainer height={400} width="100%">
+                <LineChart data={data} margin={{ top: 10, right: 10, bottom: 20, left: 10 }}>
+                    <CartesianGrid stroke={CHART_COLORS.grid} strokeDasharray="3 3" />
+                    <XAxis
+                        dataKey="drawNumber"
+                        tick={axisTickStyle}
+                        tickLine={false}
+                    />
+                    <YAxis
+                        tick={axisTickStyle}
+                        tickFormatter={formatYAxis}
+                        tickLine={false}
+                    />
+                    <Tooltip
+                        {...tooltipStyle}
+                        labelFormatter={(label) => `Draw #${label}`}
+                    />
+                    {set.keys.map((key, i) => (
+                        <Line
+                            key={key}
+                            dataKey={key}
+                            dot={false}
+                            name={set.labels[i]}
+                            stroke={CHART_PALETTE[i]}
+                            strokeWidth={1.5}
+                            type="monotone"
+                        />
+                    ))}
+                </LineChart>
+            </ResponsiveContainer>
+        </ChartCard>
+    );
+};

--- a/src/modules/analytics/components/WinnerCountChart/index.ts
+++ b/src/modules/analytics/components/WinnerCountChart/index.ts
@@ -1,0 +1,1 @@
+export { WinnerCountChart } from './WinnerCountChart';

--- a/src/modules/analytics/hooks/useAnalyticsData.ts
+++ b/src/modules/analytics/hooks/useAnalyticsData.ts
@@ -1,0 +1,60 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+import { TotoCardProps } from '@/modules/toto/components/TotoCard';
+
+import {
+    computeGapAnalysis,
+    computeHotColdNumbers,
+    computeNumberFrequency,
+    computePairFrequency
+} from '../utils/numberAnalytics';
+import {
+    computeOddEvenHighLow,
+    computeSumDistribution,
+    computeConsecutiveNumbers
+} from '../utils/patternAnalytics';
+import {
+    computeJackpotTrend,
+    computeTotalPrizePool,
+    computeWinnerCounts
+} from '../utils/prizeAnalytics';
+import { AnalyticsData } from '../utils/types';
+
+export const useAnalyticsData = () => {
+    const [draws, setDraws] = useState<TotoCardProps[]>([]);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        fetch('/api/tickets/cards')
+            .then((res) => res.json())
+            .then((res) => {
+                setDraws(res.data);
+                setLoading(false);
+            })
+            .catch((err) => {
+                console.error('Failed to load draws for analytics', err);
+                setLoading(false);
+            });
+    }, []);
+
+    const analytics = useMemo<AnalyticsData | null>(() => {
+        if (!draws.length) return null;
+        const chronological = [...draws].reverse();
+        return {
+            numberFrequency: computeNumberFrequency(chronological),
+            hotColdNumbers: computeHotColdNumbers(chronological),
+            pairFrequency: computePairFrequency(chronological),
+            gapAnalysis: computeGapAnalysis(chronological),
+            jackpotTrend: computeJackpotTrend(chronological),
+            winnerCounts: computeWinnerCounts(chronological),
+            totalPrizePool: computeTotalPrizePool(chronological),
+            oddEvenHighLow: computeOddEvenHighLow(chronological),
+            sumDistribution: computeSumDistribution(chronological),
+            consecutiveNumbers: computeConsecutiveNumbers(chronological)
+        };
+    }, [draws]);
+
+    return { analytics, loading, totalDraws: draws.length };
+};

--- a/src/modules/analytics/utils/chartTheme.ts
+++ b/src/modules/analytics/utils/chartTheme.ts
@@ -1,0 +1,38 @@
+export const CHART_COLORS = {
+    primary: '#2B71E9',
+    secondary: '#2FBB4F',
+    amber: '#F59E0B',
+    error: '#E31E1E',
+    text: '#F7F7F8',
+    textMid: '#A2A2B4',
+    textLow: '#777890',
+    grid: '#30363D',
+    background: '#161B22',
+    tooltipBg: '#0D1117'
+};
+
+export const CHART_PALETTE = [
+    '#2B71E9',
+    '#2FBB4F',
+    '#F59E0B',
+    '#EF4444',
+    '#8B5CF6',
+    '#EC4899',
+    '#06B6D4'
+];
+
+export const tooltipStyle = {
+    contentStyle: {
+        backgroundColor: '#0D1117',
+        border: '1px solid #30363D',
+        borderRadius: '8px',
+        color: '#F7F7F8',
+        fontSize: '14px'
+    },
+    labelStyle: { color: '#A2A2B4' }
+};
+
+export const axisTickStyle = {
+    fill: '#777890',
+    fontSize: 12
+};

--- a/src/modules/analytics/utils/numberAnalytics.ts
+++ b/src/modules/analytics/utils/numberAnalytics.ts
@@ -1,0 +1,118 @@
+import { TotoCardProps } from '@/modules/toto/components/TotoCard';
+
+import {
+    GapAnalysisItem,
+    HotColdItem,
+    NumberFrequencyItem,
+    PairFrequencyItem
+} from './types';
+
+const parseNums = (nums: (string | number)[]): number[] => nums.map(Number);
+
+export const computeNumberFrequency = (draws: TotoCardProps[]): NumberFrequencyItem[] => {
+    const counts = new Map<number, number>();
+    for (let i = 1; i <= 49; i++) counts.set(i, 0);
+
+    for (const draw of draws) {
+        for (const num of parseNums(draw.winningNum)) {
+            counts.set(num, (counts.get(num) ?? 0) + 1);
+        }
+    }
+
+    return Array.from(counts.entries()).map(([number, count]) => ({
+        number,
+        count,
+        percentage: (count / draws.length) * 100
+    }));
+};
+
+export const computeHotColdNumbers = (
+    draws: TotoCardProps[],
+    recentCount = 30
+): HotColdItem[] => {
+    const allTimeCounts = new Map<number, number>();
+    const recentCounts = new Map<number, number>();
+    const lastSeen = new Map<number, number>();
+
+    for (let i = 1; i <= 49; i++) {
+        allTimeCounts.set(i, 0);
+        recentCounts.set(i, 0);
+        lastSeen.set(i, draws.length);
+    }
+
+    for (let i = 0; i < draws.length; i++) {
+        const nums = parseNums(draws[i].winningNum);
+        for (const num of nums) {
+            allTimeCounts.set(num, (allTimeCounts.get(num) ?? 0) + 1);
+            if (i >= draws.length - recentCount) {
+                recentCounts.set(num, (recentCounts.get(num) ?? 0) + 1);
+            }
+            lastSeen.set(num, i);
+        }
+    }
+
+    return Array.from({ length: 49 }, (_, i) => {
+        const number = i + 1;
+        return {
+            number,
+            recentCount: recentCounts.get(number) ?? 0,
+            allTimeCount: allTimeCounts.get(number) ?? 0,
+            lastSeenDrawsAgo: draws.length - 1 - (lastSeen.get(number) ?? 0)
+        };
+    });
+};
+
+export const computePairFrequency = (draws: TotoCardProps[]): PairFrequencyItem[] => {
+    const pairCounts = new Map<string, number>();
+
+    for (const draw of draws) {
+        const nums = parseNums(draw.winningNum).sort((a, b) => a - b);
+        for (let i = 0; i < nums.length; i++) {
+            for (let j = i + 1; j < nums.length; j++) {
+                const key = `${nums[i]}-${nums[j]}`;
+                pairCounts.set(key, (pairCounts.get(key) ?? 0) + 1);
+            }
+        }
+    }
+
+    return Array.from(pairCounts.entries())
+        .map(([key, count]) => {
+            const [num1, num2] = key.split('-').map(Number);
+            return { num1, num2, count };
+        })
+        .sort((a, b) => b.count - a.count);
+};
+
+export const computeGapAnalysis = (draws: TotoCardProps[]): GapAnalysisItem[] => {
+    const appearances = new Map<number, number[]>();
+    for (let i = 1; i <= 49; i++) appearances.set(i, []);
+
+    for (let i = 0; i < draws.length; i++) {
+        for (const num of parseNums(draws[i].winningNum)) {
+            appearances.get(num)!.push(i);
+        }
+    }
+
+    return Array.from(appearances.entries()).map(([number, indices]) => {
+        if (indices.length <= 1) {
+            return {
+                number,
+                averageGap: indices.length === 0 ? draws.length : draws.length - 1,
+                maxGap: draws.length,
+                currentGap: indices.length === 0 ? draws.length : draws.length - 1 - indices[indices.length - 1]
+            };
+        }
+
+        const gaps: number[] = [];
+        for (let i = 1; i < indices.length; i++) {
+            gaps.push(indices[i] - indices[i - 1]);
+        }
+
+        return {
+            number,
+            averageGap: Math.round((gaps.reduce((a, b) => a + b, 0) / gaps.length) * 10) / 10,
+            maxGap: Math.max(...gaps),
+            currentGap: draws.length - 1 - indices[indices.length - 1]
+        };
+    });
+};

--- a/src/modules/analytics/utils/patternAnalytics.ts
+++ b/src/modules/analytics/utils/patternAnalytics.ts
@@ -1,0 +1,67 @@
+import { TotoCardProps } from '@/modules/toto/components/TotoCard';
+
+import { ConsecutiveNumbersData, OddEvenHighLowItem, SumDistributionItem } from './types';
+
+const parseNums = (nums: (string | number)[]): number[] => nums.map(Number);
+
+export const computeOddEvenHighLow = (draws: TotoCardProps[]): OddEvenHighLowItem[] => {
+    return draws.map((draw) => {
+        const nums = parseNums(draw.winningNum);
+        const oddCount = nums.filter((n) => n % 2 !== 0).length;
+        const highCount = nums.filter((n) => n >= 25).length;
+        return {
+            drawNumber: draw.drawNumber,
+            oddCount,
+            evenCount: 6 - oddCount,
+            highCount,
+            lowCount: 6 - highCount
+        };
+    });
+};
+
+export const computeSumDistribution = (draws: TotoCardProps[]): SumDistributionItem[] => {
+    const bins = new Map<string, number>();
+    const binSize = 20;
+    // Theoretical range: 21 (1+2+3+4+5+6) to 279 (44+45+46+47+48+49)
+    for (let start = 20; start <= 280; start += binSize) {
+        bins.set(`${start}-${start + binSize - 1}`, 0);
+    }
+
+    for (const draw of draws) {
+        const sum = parseNums(draw.winningNum).reduce((a, b) => a + b, 0);
+        const binStart = Math.floor(sum / binSize) * binSize;
+        const key = `${binStart}-${binStart + binSize - 1}`;
+        bins.set(key, (bins.get(key) ?? 0) + 1);
+    }
+
+    return Array.from(bins.entries())
+        .map(([sumRange, count]) => ({ sumRange, count }))
+        .filter((item) => item.count > 0);
+};
+
+export const computeConsecutiveNumbers = (draws: TotoCardProps[]): ConsecutiveNumbersData => {
+    const pairCounts: number[] = [];
+
+    for (const draw of draws) {
+        const nums = parseNums(draw.winningNum).sort((a, b) => a - b);
+        let pairs = 0;
+        for (let i = 1; i < nums.length; i++) {
+            if (nums[i] - nums[i - 1] === 1) pairs++;
+        }
+        pairCounts.push(pairs);
+    }
+
+    const distribution = new Map<number, number>();
+    for (const count of pairCounts) {
+        distribution.set(count, (distribution.get(count) ?? 0) + 1);
+    }
+
+    const drawsWithConsecutive = pairCounts.filter((c) => c > 0).length;
+
+    return {
+        distribution: Array.from(distribution.entries())
+            .map(([pairs, count]) => ({ pairs, count }))
+            .sort((a, b) => a.pairs - b.pairs),
+        percentageWithConsecutive: Math.round((drawsWithConsecutive / draws.length) * 1000) / 10
+    };
+};

--- a/src/modules/analytics/utils/prizeAnalytics.ts
+++ b/src/modules/analytics/utils/prizeAnalytics.ts
@@ -1,0 +1,42 @@
+import { TotoCardProps } from '@/modules/toto/components/TotoCard';
+
+import { JackpotTrendItem, TotalPrizePoolItem, WinnerCountItem } from './types';
+
+export const computeJackpotTrend = (draws: TotoCardProps[]): JackpotTrendItem[] => {
+    return draws.map((draw) => {
+        const group1 = draw.winningPool[0];
+        return {
+            drawNumber: draw.drawNumber,
+            drawDate: draw.drawDate,
+            prize: group1?.prize ?? 0,
+            winners: group1?.winners ?? 0
+        };
+    });
+};
+
+export const computeWinnerCounts = (draws: TotoCardProps[]): WinnerCountItem[] => {
+    return draws.map((draw) => ({
+        drawNumber: draw.drawNumber,
+        drawDate: draw.drawDate,
+        group1: draw.winningPool[0]?.winners ?? 0,
+        group2: draw.winningPool[1]?.winners ?? 0,
+        group3: draw.winningPool[2]?.winners ?? 0,
+        group4: draw.winningPool[3]?.winners ?? 0,
+        group5: draw.winningPool[4]?.winners ?? 0,
+        group6: draw.winningPool[5]?.winners ?? 0,
+        group7: draw.winningPool[6]?.winners ?? 0
+    }));
+};
+
+export const computeTotalPrizePool = (draws: TotoCardProps[]): TotalPrizePoolItem[] => {
+    return draws.map((draw) => {
+        const totalPool = draw.winningPool.reduce((sum, pool) => {
+            return sum + (pool.prize ?? 0) * (pool.winners ?? 0);
+        }, 0);
+        return {
+            drawNumber: draw.drawNumber,
+            drawDate: draw.drawDate,
+            totalPool
+        };
+    });
+};

--- a/src/modules/analytics/utils/types.ts
+++ b/src/modules/analytics/utils/types.ts
@@ -1,0 +1,81 @@
+export interface NumberFrequencyItem {
+    number: number;
+    count: number;
+    percentage: number;
+}
+
+export interface HotColdItem {
+    number: number;
+    recentCount: number;
+    allTimeCount: number;
+    lastSeenDrawsAgo: number;
+}
+
+export interface PairFrequencyItem {
+    num1: number;
+    num2: number;
+    count: number;
+}
+
+export interface GapAnalysisItem {
+    number: number;
+    averageGap: number;
+    maxGap: number;
+    currentGap: number;
+}
+
+export interface JackpotTrendItem {
+    drawNumber: number;
+    drawDate: string;
+    prize: number;
+    winners: number;
+}
+
+export interface WinnerCountItem {
+    drawNumber: number;
+    drawDate: string;
+    group1: number;
+    group2: number;
+    group3: number;
+    group4: number;
+    group5: number;
+    group6: number;
+    group7: number;
+}
+
+export interface TotalPrizePoolItem {
+    drawNumber: number;
+    drawDate: string;
+    totalPool: number;
+}
+
+export interface OddEvenHighLowItem {
+    drawNumber: number;
+    oddCount: number;
+    evenCount: number;
+    highCount: number;
+    lowCount: number;
+}
+
+export interface SumDistributionItem {
+    sumRange: string;
+    count: number;
+}
+
+export interface ConsecutiveNumbersData {
+    distribution: { pairs: number; count: number }[];
+    percentageWithConsecutive: number;
+}
+
+export interface AnalyticsData {
+    numberFrequency: NumberFrequencyItem[];
+    hotColdNumbers: HotColdItem[];
+    pairFrequency: PairFrequencyItem[];
+    gapAnalysis: GapAnalysisItem[];
+    jackpotTrend: JackpotTrendItem[];
+    winnerCounts: WinnerCountItem[];
+    totalPrizePool: TotalPrizePoolItem[];
+    oddEvenHighLow: OddEvenHighLowItem[];
+    sumDistribution: SumDistributionItem[];
+    consecutiveNumbers: ConsecutiveNumbersData;
+}


### PR DESCRIPTION
## Description

Added a comprehensive analytics dashboard to visualize Toto lottery data with 10 charts across 3 sections, plus a shared navigation bar between Draw and Analytics pages.

### Features

**Navigation:**
- New NavBar component with Draw and Analytics tabs (sticky, dark-themed)
- Highlights active route with blue underline

**Number Analytics:**
- Number Frequency: Bar chart showing appearance count for all numbers 1-49
- Hot & Cold Numbers: Grouped bars comparing recent vs all-time frequency with toggle
- Number Pair Heatmap: Custom SVG grid with co-occurrence frequency + top 20 pairs table
- Gap Analysis: Bar chart showing average draws between appearances, with expected gap reference line and red highlighting for overdue numbers

**Prize & Winner Analytics:**
- Jackpot Trend: Area chart of Group 1 prizes over time, reveals rollovers
- Winner Count Trends: Multi-line chart with toggle between Groups 1-4 and Groups 5-7
- Total Prize Pool: Area chart of total payouts (sum of prize × winners) per draw

**Pattern Analytics:**
- Odd/Even & High/Low Distribution: Stacked bars per draw + donut summary with toggle
- Sum Distribution: Histogram showing frequency of winning number sums
- Consecutive Numbers: Bar chart of consecutive pair frequency + percentage stat

### Technical Details

- Uses Recharts 3.7 for visualization with dark theme colors
- Client-side computation of all analytics from existing /api/tickets/cards endpoint
- 312 draws of data analyzed across ~3 years (March 2023 - Feb 2026)
- Shared ChartCard component and chartTheme utilities for consistency
- All charts responsive and mobile-friendly

### Files Added/Modified

- 36 files changed: 30 new files created, 3 modified (layout.tsx, package.json, pnpm-lock.yaml)
- ~1,688 lines of code added